### PR TITLE
Add CancellationToken to file download methods

### DIFF
--- a/src/Gml.Client/GmlClientManager.cs
+++ b/src/Gml.Client/GmlClientManager.cs
@@ -50,12 +50,12 @@ public class GmlClientManager : IGmlClientManager
     public Task<Process> GetProcess(ProfileReadInfoDto profileDto)
         => _apiProcedures.GetProcess(profileDto, _installationDirectory);
 
-    public async Task DownloadNotInstalledFiles(ProfileReadInfoDto profileInfo)
+    public async Task DownloadNotInstalledFiles(ProfileReadInfoDto profileInfo, CancellationToken cancellationToken = default)
     {
         await _systemProcedures.RemoveFiles(profileInfo);
 
         var updateFiles = _systemProcedures.FindErroneousFiles(profileInfo, _installationDirectory);
-        await _apiProcedures.DownloadFiles(_installationDirectory, updateFiles.ToArray(), 16);
+        await _apiProcedures.DownloadFiles(_installationDirectory, updateFiles.ToArray(), 16, cancellationToken);
     }
 
     public Task<(IUser User, string Message, IEnumerable<string> Details)> Auth(string login, string password)

--- a/src/Gml.Client/IGmlClientManager.cs
+++ b/src/Gml.Client/IGmlClientManager.cs
@@ -13,7 +13,7 @@ public interface IGmlClientManager
     Task<ResponseMessage<List<ProfileReadDto>>> GetProfiles();
     Task<ResponseMessage<ProfileReadInfoDto?>?> GetProfileInfo(ProfileCreateInfoDto profileDto);
     public Task<Process> GetProcess(ProfileReadInfoDto profileDto);
-    Task DownloadNotInstalledFiles(ProfileReadInfoDto profileInfo);
+    Task DownloadNotInstalledFiles(ProfileReadInfoDto profileInfo, CancellationToken cancellationToken);
     Task<(IUser User, string Message, IEnumerable<string> Details)> Auth(string login, string password);
     Task ClearFiles(ProfileReadInfoDto profile);
     Task LoadDiscordRpc();


### PR DESCRIPTION
This commit adds a CancellationToken parameter to all file download related methods in the ApiProcedures class to help manage long-running and potentially cancelable operations. This change included updates to both the Gml.ClientManager and IGmlClientManager classes to reflect the method modifications. Additionally, redundant usage of System.Security.Cryptography namespace has been removed.