### PR TITLE
Update path handling and monitoring in file watcher

### DIFF
--- a/src/Gml.Client/Helpers/SystemIOProcedures.cs
+++ b/src/Gml.Client/Helpers/SystemIOProcedures.cs
@@ -62,7 +62,14 @@ public class SystemIoProcedures
     {
         try
         {
-            var profilePath = _installationDirectory + @"\clients\" + profileInfo.ProfileName;
+            string[] allowedPaths =
+            [
+                Path.Combine(_installationDirectory, "clients", profileInfo.ProfileName, "saves"),
+                Path.Combine(_installationDirectory, "clients", profileInfo.ProfileName, "logs"),
+                Path.Combine(_installationDirectory, "clients", profileInfo.ProfileName, "crash-reports")
+            ];
+
+            var profilePath = Path.Combine(_installationDirectory, "clients", profileInfo.ProfileName);
 
             var directoryInfo = new DirectoryInfo(profilePath);
 
@@ -80,11 +87,11 @@ public class SystemIoProcedures
 
             var exclusionSet = new HashSet<string>(hashSet);
 
-            var missingFiles = files
-                .Where(f => !exclusionSet.Contains(f.FullName))
+            var filesToRemove = files
+                .Where(f => !exclusionSet.Contains(f.FullName) && !allowedPaths.Any(path => f.FullName.StartsWith(path)))
                 .ToList();
 
-            foreach (var file in missingFiles)
+            foreach (var file in filesToRemove)
             {
                 try
                 {


### PR DESCRIPTION
The main focus of this commit is enhancing how directories are managed and how file changes are detected in the Gml.Client project. The SystemIOProcedures class now specifies a list of paths to be monitored, instead of just including the profile directory. Furthermore, in ApiProcedures, the handling of ProfileFileWatcher instances has been revised to differentiate between mod and asset directories. Changes in the ProfileFileWatcher class include adding a flag to determine whether changes should cause the process to be killed.