### PR TITLE
Add hardware ID parameter in authentication method

### DIFF
--- a/src/Gml.Client/GmlClientManager.cs
+++ b/src/Gml.Client/GmlClientManager.cs
@@ -58,8 +58,8 @@ public class GmlClientManager : IGmlClientManager
         await _apiProcedures.DownloadFiles(_installationDirectory, updateFiles.ToArray(), 16, cancellationToken);
     }
 
-    public Task<(IUser User, string Message, IEnumerable<string> Details)> Auth(string login, string password)
-        => _apiProcedures.Auth(login, password);
+    public Task<(IUser User, string Message, IEnumerable<string> Details)> Auth(string login, string password, string hwid)
+        => _apiProcedures.Auth(login, password, hwid);
 
     public Task ClearFiles(ProfileReadInfoDto profile) => _systemProcedures.RemoveFiles(profile);
 

--- a/src/Gml.Client/Helpers/ApiProcedures.cs
+++ b/src/Gml.Client/Helpers/ApiProcedures.cs
@@ -166,7 +166,7 @@ public class ApiProcedures
         return string.Empty;
     }
 
-    public async Task<(IUser User, string Message, IEnumerable<string> Details)> Auth(string login, string password)
+    public async Task<(IUser User, string Message, IEnumerable<string> Details)> Auth(string login, string password, string hwid)
     {
         var model = JsonConvert.SerializeObject(new BaseUserPassword
         {
@@ -180,9 +180,9 @@ public class ApiProcedures
         };
 
         var data = new StringContent(model, Encoding.UTF8, "application/json");
-
+        _httpClient.DefaultRequestHeaders.Add("X-HWID", hwid);
         var response = await _httpClient.PostAsync("/api/v1/integrations/auth/signin", data).ConfigureAwait(false);
-
+        _httpClient.DefaultRequestHeaders.Remove("X-HWID");
         authUser.IsAuth = response.IsSuccessStatusCode;
 
         var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/Gml.Client/IGmlClientManager.cs
+++ b/src/Gml.Client/IGmlClientManager.cs
@@ -14,7 +14,7 @@ public interface IGmlClientManager
     Task<ResponseMessage<ProfileReadInfoDto?>?> GetProfileInfo(ProfileCreateInfoDto profileDto);
     public Task<Process> GetProcess(ProfileReadInfoDto profileDto);
     Task DownloadNotInstalledFiles(ProfileReadInfoDto profileInfo, CancellationToken cancellationToken);
-    Task<(IUser User, string Message, IEnumerable<string> Details)> Auth(string login, string password);
+    Task<(IUser User, string Message, IEnumerable<string> Details)> Auth(string login, string password, string hwid);
     Task ClearFiles(ProfileReadInfoDto profile);
     Task LoadDiscordRpc();
     Task UpdateDiscordRpcState(string state);


### PR DESCRIPTION
The Auth method was updated to include a new parameter, the hardware ID (hwid), to strengthen the security of the login process in the Gml.Client. Consequently, the Auth method signature was also amended across the ApiProcedures, IGmlClientManager and GmlClientManager classes to accommodate this change.