### PR TITLE
Add OS type information to profile and refactor path adjustments

### DIFF
--- a/src/Gml.Client/Helpers/SystemIOProcedures.cs
+++ b/src/Gml.Client/Helpers/SystemIOProcedures.cs
@@ -33,7 +33,7 @@ public class SystemIoProcedures
                 downloadingFile.Directory = downloadingFile.Directory.Replace('/', Path.DirectorySeparatorChar).TrimStart(Path.DirectorySeparatorChar);
             }
 
-            string localPath = Path.Combine(installationDirectory, downloadingFile.Directory);
+            string localPath = Path.Combine(installationDirectory, downloadingFile.Directory.TrimStart('\\').TrimStart(Path.DirectorySeparatorChar));
 
             if (FileExists(localPath))
             {
@@ -50,7 +50,7 @@ public class SystemIoProcedures
             }
         });
 
-        return errorFiles.ToList();
+        return errorFiles.OrderByDescending(c => c.Size).ToList();
     }
 
     private static bool FileExists(string path)
@@ -118,6 +118,6 @@ public class SystemIoProcedures
             file.Directory = file.Directory.Replace('/', Path.DirectorySeparatorChar).TrimStart(Path.DirectorySeparatorChar);
         }
 
-        return Path.Combine(installationDirectory, file.Directory);
+        return Path.Combine(installationDirectory, file.Directory.TrimStart('\\').TrimStart(Path.DirectorySeparatorChar));
     }
 }

--- a/src/Gml.Web.Api.Dto/Profile/ProfileReadInfoDto.cs
+++ b/src/Gml.Web.Api.Dto/Profile/ProfileReadInfoDto.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Gml.Web.Api.Domains.System;
 using Gml.Web.Api.Dto.Files;
 
 namespace Gml.Web.Api.Dto.Profile;
@@ -16,4 +17,5 @@ public class ProfileReadInfoDto
     public List<ProfileFileReadDto> Files { get; set; }
     public List<ProfileFileReadDto> WhiteListFiles { get; set; }
     public string Background { get; set; }
+    public OsType OsType { get; set; }
 }


### PR DESCRIPTION
Additional operating system (OS) type has been added to profile information. Path adjustments related to file download and directory specification have been refactored. For the downloaded files, the listed order has been updated to descending based on the file size. Additional precautions are in place for process start depending on the OS type.